### PR TITLE
Fix for issue #61

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -936,7 +936,7 @@ class EpubReader(object):
             values.append((value, extra))
 
         for t in metadata:
-            if not etree.iselement(t):
+            if not etree.iselement(t) or t.tag is etree.Comment:
                 continue
             if t.tag == default_ns + 'meta':
                 name = t.get('name')


### PR DESCRIPTION
read_epub is failing on epubs which contain Comments in their metadata.

This skips over any Comment elements when reading metadata.
