### PR TITLE
Use relative paths in toc nav

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -21,6 +21,7 @@ import six
 import mimetypes
 import logging
 import posixpath as zip_path
+import os.path
 
 try:
     from urllib.parse import unquote
@@ -706,6 +707,7 @@ class EpubWriter(object):
         root.set('lang', self.book.language)
         root.attrib['{%s}lang' % NAMESPACES['XML']] = self.book.language
 
+        nav_dir_name = os.path.dirname(item.file_name)
 
         head = etree.SubElement(root, 'head')
         title = etree.SubElement(head, 'title')
@@ -727,7 +729,7 @@ class EpubWriter(object):
                 if isinstance(item, tuple) or isinstance(item, list):
                     li = etree.SubElement(ol, 'li')
                     if isinstance(item[0], EpubHtml):
-                        a = etree.SubElement(li, 'a', {'href': item[0].file_name})
+                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].file_name, nav_dir_name)})
                     else:
                         a = etree.SubElement(li, 'span')
                     a.text = item[0].title
@@ -736,11 +738,12 @@ class EpubWriter(object):
 
                 elif isinstance(item, Link):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': item.href})
+                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.href, nav_dir_name)})
                     a.text = item.title
                 elif isinstance(item, EpubHtml):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': item.file_name})
+                    
+                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.file_name, nav_dir_name)})
                     a.text = item.title
 
         _create_section(nav, self.book.toc)
@@ -768,7 +771,7 @@ class EpubWriter(object):
                     _href = elem.get('href', '')
                     _title = elem.get('title', '')
 
-                a_item = etree.SubElement(li_item, 'a', {'{%s}type' % NAMESPACES['EPUB']: elem.get('type', ''), 'href': _href})
+                a_item = etree.SubElement(li_item, 'a', {'{%s}type' % NAMESPACES['EPUB']: elem.get('type', ''), 'href': os.path.relpath(_href, nav_dir_name)})
                 a_item.text = _title
 
         tree_str = etree.tostring(root, pretty_print=True, encoding='utf-8', xml_declaration=True)


### PR DESCRIPTION
It's not necessarily the case that an epub's nav file is in the root dir; currently ebooklib makes that assumption. An item's file_name attribute is relative to the root dir. Therefore it's necessary to ensure the links in the nav file are relative to the nav file's current path.