### PR TITLE
Ensure only new modified date is included

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -574,6 +574,8 @@ class EpubWriter(object):
             if ns_name == NAMESPACES['OPF']:
                 for values in values.values():
                     for v in values:
+                        if 'property' in v[1] and v[1]['property'] == "dcterms:modified":
+                            continue
                         try:
                             el = etree.SubElement(metadata, 'meta', v[1])
                             if v[0]:


### PR DESCRIPTION
ebooklib creates a fresh dcterms:modified meta element. Therefore if the lib is loading an existing epub with its own dcterms:modified element then for the sake of epub3 conformance we must omit the original one in favour of the new element.