### PR TITLE
Fixed installation error in python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url = 'https://github.com/aerkalov/ebooklib',
     license = 'GNU Affero General Public License',
     description = 'Ebook library which can handle EPUB2/EPUB3 and Kindle format',
-    long_description = open('README.md').read(),
+    long_description = open('README.md',"rb").read().decode('utf8'),
     keywords = ['ebook', 'epub', 'kindle'],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This fixes a bug while installing this library in python3 (and possibly in python2 too).
After changing this I was able to install it on both ubuntu and Mac OS X