### PR TITLE
Setting _title to '' instead of None to prevent error

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -39,7 +39,7 @@ mimetypes.add_type('application/xhtml+xml', '.xhtml')
 
 
 # Version of EPUB library
-VERSION = (0, 15, 0)
+VERSION = (0, 15, 1)
 
 NAMESPACES = {'XML': 'http://www.w3.org/XML/1998/namespace',
               'EPUB': 'http://www.idpf.org/2007/ops',
@@ -713,7 +713,10 @@ class EpubWriter(object):
                 else:
                     _href = item.get('href', '')
                     _title = item.get('title', '')
-
+                    
+                if _title is None:
+                    _title = ''
+                
                 ref = etree.SubElement(guide, 'reference', {'type': item.get('type', ''),
                                                             'title': _title,
                                                             'href': _href})

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name = 'EbookLib',
-    version = '0.15',
+    version = '0.15.1-rdhyee',
     author = 'Aleksandar Erkalovic',
     author_email = 'aerkalov@gmail.com',
     packages = ['ebooklib', 'ebooklib.plugins'],


### PR DESCRIPTION
I read in https://github.com/GITenberg/Adventures-of-Huckleberry-Finn_76/releases/download/0.0.21/Adventures-of-Huckleberry-Finn.epub into `ebooklib.epub.read_epub` and then wanted to write the book back out.  In order to handle an issue in which the title of an element in the guide is `None`, I change the `_title` to '' instead.  [IDPF/epubcheck](https://github.com/idpf/epubcheck) did not flag any errors in the epub, so I thought a good place to handle this problem is with this change in `ebooklib`.  (If you accept the PR,  please adjust the version number)