### PR TITLE
Set blank title if it is None

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -714,6 +714,8 @@ class EpubWriter(object):
                     _href = item.get('href', '')
                     _title = item.get('title', '')
 
+                if _title is None:
+                    _title = ''
                 ref = etree.SubElement(guide, 'reference', {'type': item.get('type', ''),
                                                             'title': _title,
                                                             'href': _href})


### PR DESCRIPTION
I read in an epub that was missing an title and then immediately tried to save it and got:

    Traceback (most recent call last):
      File "experiment.py", line 11, in <module>
        epub.write_epub(output_filename, book, {})
      File "C:\Users\clach04\py\ebooklib\ebooklib\epub.py", line 1220, in write_epub
        epub.write()
      File "C:\Users\clach04\py\ebooklib\ebooklib\epub.py", line 913, in write
        self._write_opf_file()
      File "C:\Users\clach04\py\ebooklib\ebooklib\epub.py", line 723, in _write_opf_file
        'href': _href})
      File "lxml.etree.pyx", line 3006, in lxml.etree.SubElement (src\lxml\lxml.etree.c:69555)
      File "apihelpers.pxi", line 208, in lxml.etree._makeSubElement (src\lxml\lxml.etree.c:15876)
      File "apihelpers.pxi", line 203, in lxml.etree._makeSubElement (src\lxml\lxml.etree.c:15811)
      File "apihelpers.pxi", line 287, in lxml.etree._initNodeAttributes (src\lxml\lxml.etree.c:17012)
      File "apihelpers.pxi", line 297, in lxml.etree._addAttributeToNode (src\lxml\lxml.etree.c:17192)
      File "apihelpers.pxi", line 1391, in lxml.etree._utf8 (src\lxml\lxml.etree.c:27100)
    TypeError: Argument must be bytes or unicode, got 'NoneType'

Test code:

    from ebooklib import epub
    import ebooklib

    input_filename = 'mytest.epub'
    output_filename = 'outtest.epub'

    book = epub.read_epub(input_filename)

    epub.write_epub(output_filename, book, {})
