### PR TITLE
Etree python 3.5 fix

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -20,6 +20,7 @@ import mimetypes
 import logging
 import uuid
 import posixpath as zip_path
+import sys
 
 try:
     from urllib.parse import unquote
@@ -218,7 +219,11 @@ class EpubHtml(EpubItem):
         if len(html_root.find('body')) != 0:
             body = html_tree.find('body')
 
-            tree_str = etree.tostring(body, pretty_print=True, encoding='utf-8', xml_declaration=False)
+            if sys.version_info >= (3, 0):
+                tree_str = etree.tostring(body, encoding='unicode')
+            else:
+                tree_str = etree.tostring(body, pretty_print=True, encoding='utf-8', xml_declaration=False)
+
             # this is so stupid
             if tree_str.startswith('<body>'):
                 n = tree_str.rindex('</body>')


### PR DESCRIPTION
I've found some problems with etree and python 3. Etree component was returning bites in python 3 instead of unicode string and I made small change to fix this problems.

[https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring](XML etree documentation)

> Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated)