### PR TITLE
Missed doctype in the nav.xhtml file

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1018,8 +1018,8 @@ class EpubWriter(object):
 
     def _get_nav(self, item):
         # just a basic navigation for now
-        ncx = parse_string(self.book.get_template('nav'))
-        root = ncx.getroot()
+        nav_xml = parse_string(self.book.get_template('nav'))
+        root = nav_xml.getroot()
 
         root.set('lang', self.book.language)
         root.attrib['{%s}lang' % NAMESPACES['XML']] = self.book.language
@@ -1102,7 +1102,7 @@ class EpubWriter(object):
                 a_item = etree.SubElement(li_item, 'a', {'{%s}type' % NAMESPACES['EPUB']: guide_to_landscape_map.get(guide_type, guide_type), 'href': os.path.relpath(_href, nav_dir_name)})
                 a_item.text = _title
 
-        tree_str = etree.tostring(root, pretty_print=True, encoding='utf-8', xml_declaration=True)
+        tree_str = etree.tostring(nav_xml, pretty_print=True, encoding='utf-8', xml_declaration=True)
 
         return tree_str
 


### PR DESCRIPTION
Hi @aerkalov 
Please, take a look at this pr. 
DOCTYPE was missed in the nav.xhtml file, this pr should fix it. 
Check attached image, it shows the difference:
![screen shot 2017-02-15 at 17 11 14](https://cloud.githubusercontent.com/assets/4199922/22983295/f3d29b8e-f3a1-11e6-8198-2cfbafbc479d.png)
 