### PR TITLE
Attribute ordering of meta tag

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -20,6 +20,7 @@ import logging
 import uuid
 import posixpath as zip_path
 import os.path
+from collections import OrderedDict
 
 try:
     from urllib.parse import unquote
@@ -612,7 +613,7 @@ class EpubBook(object):
             c1 = EpubCoverHtml(image_name=file_name)
             self.add_item(c1)
 
-        self.add_metadata(None, 'meta', '', {'name': 'cover', 'content': 'cover-img'})
+        self.add_metadata(None, 'meta', '', OrderedDict([('name', 'cover'), ('content', 'cover-img')]))
 
     def add_author(self, author, file_as=None, role=None, uid='creator'):
         "Add author for this document"


### PR DESCRIPTION
in meta tag name should appear earlier than content attribute

from calibre ebook-edit check
>Some ebook readers such as the Nook fail to recognize covers if the content attribute comes before the name attribute. For maximum compatibility move the name attribute before the content attribute.