### PR TITLE
Enable utf8 in TidyPlugin

### DIFF
--- a/ebooklib/plugins/tidyhtml.py
+++ b/ebooklib/plugins/tidyhtml.py
@@ -27,10 +27,12 @@ def tidy_cleanup(content, **extra):
     cmd = []
 
     for k, v in six.iteritems(extra):
-    	cmd.append('--%s' % k)
 
-    	if v:
-    		cmd.append(v)
+        if v:
+            cmd.append('--%s' % k)
+            cmd.append(v)
+        else:
+            cmd.append('-%s' % k)
 
     # must parse all other extra arguments
     try:
@@ -54,7 +56,7 @@ def tidy_cleanup(content, **extra):
 
 class TidyPlugin(BasePlugin):
     NAME = 'Tidy HTML'
-    OPTIONS = {'utf8': None,
+    OPTIONS = {'char-encoding': 'utf8',
                'tidy-mark': 'no'
               }
 


### PR DESCRIPTION
http://tidy.sourceforge.net/docs/quickref.html#char-encoding
should --char-encoding utf8 instead of --utf8 (invalid option)

<img width="606" alt="screen shot 2017-02-26 at 12 48 03 pm" src="https://cloud.githubusercontent.com/assets/1933134/23337250/d90e86ae-fc21-11e6-9b89-7d786c8693e3.png">
