### PR TITLE
Don't cut off first character of body in EpubHtml.get_body_content()

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -351,7 +351,7 @@ class EpubHtml(EpubItem):
             if tree_str.startswith(six.b('<body>')):
                 n = tree_str.rindex(six.b('</body>'))
 
-                return tree_str[7:n]
+                return tree_str[6:n]
 
             return tree_str
 


### PR DESCRIPTION
`<body>` is only 6 characters long, but `tree_str[7:n]` cuts off 7 :slightly_smiling_face:.

Thanks for this project, by the way! I'm finding it pretty handy.