### PR TITLE
Adding support for the EPUB3 pagebreak/page-list semantics.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,12 @@ Writing
     c1 = epub.EpubHtml(title='Intro', file_name='chap_01.xhtml', lang='hr')
     c1.content=u'<h1>Intro heading</h1><p>Žaba je skočila u baru.</p>'
 
+    # Add invisible page numbers that match the printed text, for accessibility
+    c1.add_pageref("id_page_1")
+
+    # Add visible page numbers that match the printed text, for accessibility
+    c1.add_pageref("id_page_2", label="Page 2")
+
     # add chapter
     book.add_item(c1)
 

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -82,7 +82,7 @@ COVER_XML = six.b('''<?xml version="1.0" encoding="UTF-8"?>
 IMAGE_MEDIA_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/svg+xml']
 
 
-# TOC elements
+# TOC and navigation elements
 
 class Section(object):
 
@@ -313,6 +313,32 @@ class EpubHtml(EpubItem):
         """
         return (link for link in self.links if link.get('type', '') == link_type)
 
+    def add_pageref(self, pageref, label=None):
+        """
+        Create a pagebreak element with optional visible content.
+        Append to the current end of the EpubHtml content.
+        Save for the page-list in the nav.
+        """
+
+        pageref_attributes = {
+                              '{%s}type' % NAMESPACES['EPUB']: 'pagebreak',
+                              'title': u'{}'.format(pageref),
+                              'id': u'{}'.format(pageref),
+                             }
+
+        pageref_elem = etree.Element('span', pageref_attributes)
+
+        if label:
+            pageref_elem.text = label
+
+        # Append a tuple to the pages list: The filename of this EpubHtml
+        # object, the id to reference, and a label to be used in the page-list.
+        self.book.pages.append((self.file_name, pageref, label or pageref))
+
+        # Append this pageref to the HTML content
+        self.content += etree.tostring(pageref_elem, encoding='unicode')
+
+
     def add_item(self, item):
         """
         Add other item to this document. It will create additional links according to the item type.
@@ -533,6 +559,7 @@ class EpubBook(object):
         self.items = []
         self.spine = []
         self.guide = []
+        self.pages = []
         self.toc = []
         self.bindings = []
 
@@ -833,7 +860,9 @@ class EpubWriter(object):
     DEFAULT_OPTIONS = {
         'epub2_guide': True,
         'epub3_landmark': True,
+        'epub3_pages': True,
         'landmark_title': 'Guide',
+        'pages_title': 'Pages',
         'spine_direction': True,
         'package_direction': False
     }
@@ -1145,6 +1174,35 @@ class EpubWriter(object):
                 a_item = etree.SubElement(li_item, 'a', {
                     '{%s}type' % NAMESPACES['EPUB']: guide_to_landscape_map.get(guide_type, guide_type),
                     'href': os.path.relpath(_href, nav_dir_name)
+                })
+                a_item.text = _title
+
+        # PAGE-LIST
+        if len(self.book.pages) > 0 and self.options.get('epub3_pages'):
+            pagelist_nav = etree.SubElement(
+                body,
+                'nav',
+                {
+                    '{%s}type' % NAMESPACES['EPUB']: 'page-list',
+                    'id': 'pages',
+                    'hidden': 'hidden',
+                }
+            )
+            pagelist_content_title = etree.SubElement(pagelist_nav, 'h2')
+            pagelist_content_title.text = self.options.get(
+                'pages_title', 'Pages'
+            )
+
+            pages_ol = etree.SubElement(pagelist_nav, 'ol')
+
+            for filename, pageref, label in self.book.pages:
+                li_item = etree.SubElement(pages_ol, 'li')
+
+                _href = u'{}#{}'.format(filename, pageref)
+                _title = label
+
+                a_item = etree.SubElement(li_item, 'a', {
+                    'href': os.path.relpath(_href, nav_dir_name),
                 })
                 a_item.text = _title
 
@@ -1461,9 +1519,14 @@ class EpubReader(object):
 
         self.book.toc = _get_children(nav_map, 0, '')
 
-    def _parse_nav(self, data, base_path):
+    def _parse_nav(self, data, base_path, navtype='toc'):
         html_node = parse_html_string(data)
-        nav_node = html_node.xpath("//nav[@*='toc']")[0]
+        if navtype == 'toc':
+            # parsing the table of contents
+            nav_node = html_node.xpath("//nav[@*='toc']")[0]
+        else:
+            # parsing the list of pages
+            nav_node = html_node.xpath("//nav[@*='page-list']")[0]
 
         def parse_list(list_node):
             items = []
@@ -1490,7 +1553,10 @@ class EpubReader(object):
 
             return items
 
-        self.book.toc = parse_list(nav_node.find('ol'))
+        if navtype == 'toc':
+            self.book.toc = parse_list(nav_node.find('ol'))
+        elif nav_node is not None:
+            self.book.pages = parse_list(nav_node.find('ol'))
 
     def _load_spine(self):
         spine = self.container.find('{%s}%s' % (NAMESPACES['OPF'], 'spine'))
@@ -1529,10 +1595,19 @@ class EpubReader(object):
 
         # read nav file if found
         #
-        if not self.book.toc:
-            nav_item = next((item for item in self.book.items if isinstance(item, EpubNav)), None)
-            if nav_item:
-                self._parse_nav(nav_item.content, zip_path.dirname(nav_item.file_name))
+        nav_item = next((item for item in self.book.items if isinstance(item, EpubNav)), None)
+        if nav_item:
+            if not self.book.toc:
+                self._parse_nav(
+                    nav_item.content,
+                    zip_path.dirname(nav_item.file_name),
+                    navtype='toc'
+                )
+            self._parse_nav(
+                nav_item.content,
+                zip_path.dirname(nav_item.file_name),
+                navtype='pages'
+            )
 
     def _load(self):
         try:

--- a/samples/07_pagebreaks/README.md
+++ b/samples/07_pagebreaks/README.md
@@ -1,0 +1,8 @@
+Advanced create
+===============
+
+Create simple EPUB3 with both visible and invisible pagebreaks
+
+## Start
+
+    python create.py

--- a/samples/07_pagebreaks/create.py
+++ b/samples/07_pagebreaks/create.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+
+from ebooklib import epub
+
+
+if __name__ == '__main__':
+    book = epub.EpubBook()
+
+    # add metadata
+    book.set_identifier('sample123456')
+    book.set_title('Sample book')
+    book.set_language('en')
+
+    book.add_author('Aleksandar Erkalovic')
+
+    # build the chapter HTML and add the page break
+    c1 = epub.EpubHtml(title='Introduction', file_name='intro.xhtml', lang='en')
+    c1.content = u'<html><head></head><body><h1>Introduction</h1><p>This chapter has a visible page number.</p>'
+
+    # Add visible page numbers that match the printed text, for accessibility
+    c1.add_pageref("1", label="Page 1")
+
+    # close the chapter
+    c1.content += u'</body></html>'
+
+    c2 = epub.EpubHtml(title='Chapter the Second', file_name='chap02.xhtml', lang='en')
+    c2.content = u'<html><head></head><body><h1>Chapter the Second</h1><p>This chapter has two page breaks, both with invisible page numbers.</p>'
+
+    # Add invisible page numbers that match the printed text, for accessibility
+    c2.add_pageref("2")
+
+    # You can add more content  after the page break
+    c2.content += u'<p>This is the second page in the second chapter, after the invisible page break.</p>'
+
+    # Add invisible page numbers that match the printed text, for accessibility
+    c2.add_pageref("3")
+
+    # close the chapter
+    c2.content += u'</body></html>'
+
+    # add chapters to the book
+    book.add_item(c1)
+    book.add_item(c2)
+    
+    # create table of contents
+    # - add manual link
+    # - add section
+    # - add auto created links to chapters
+
+    book.toc = ((c1, c2, ))
+
+    # add navigation files
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+
+    # create spine
+    book.spine = ['nav', c1, c2, ]
+
+    # create epub file
+    epub.write_epub('test.epub', book, {})
+


### PR DESCRIPTION
These semantics allow pagebreak elements to be created that correspond the pagenumbers in a printed text. This is for accessibility, or allow people to use digital and print editions concurrently (e.g. so an instructor can tell the students to turn to page 37, and students using both print and EPUB additions can turn to the same page).

By default, these preferences will be invisible,  intended to be supported by reading systems.

c.add_pageref adds a new page reference  to the current end of c.content

with the optional parameter "label" that page reference becomes visible.

The page-list is created as invisible  here, only to be exposed by reading systems. (ibooks is an example of a reading system that correctly parses the page-list.)