### PR TITLE
Fixed #132 - Read the ``README.md`` file using utf-8 encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 #from distutils.core import setup
+import io
+
 from setuptools import setup
+
+
+def read(path):
+    with io.open(path, mode="r", encoding="utf-8") as fd:
+        return fd.read()
+
 
 setup(
     name = 'EbookLib',
@@ -10,7 +18,7 @@ setup(
     url = 'https://github.com/aerkalov/ebooklib',
     license = 'GNU Affero General Public License',
     description = 'Ebook library which can handle EPUB2/EPUB3 and Kindle format',
-    long_description = open('README.md').read(),
+    long_description = read('README.md'),
     keywords = ['ebook', 'epub', 'kindle'],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Hi,

The aim of this pull request is to fix issue #132 by specifying the utf-8 encoding while reading `README.md`.

Note that specifying the encoding is a requirement on Python 2.7.

Regards,
– Laurent.
