### PR TITLE
Make `samples/04_markdown_parse` Python 2+3 compatible

### DIFF
--- a/samples/04_markdown_parse/epub2markdown.py
+++ b/samples/04_markdown_parse/epub2markdown.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
-
-import sys
-import subprocess
-import os
 import os.path
+import subprocess
+import sys
 
 from ebooklib import epub
 
@@ -21,23 +19,20 @@ if __name__ == '__main__':
         if isinstance(item, epub.EpubHtml):
             proc = subprocess.Popen(['pandoc', '-f', 'html', '-t', 'markdown', '-'],
                                     stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE
-                                    )
+                                    stdout=subprocess.PIPE)
             content, error = proc.communicate(item.content)
-            file_name = os.path.splitext(item.file_name)[0]+'.md'
+            file_name = os.path.splitext(item.file_name)[0] + '.md'
         else:
             file_name = item.file_name
             content = item.content
 
         # create needed directories 
-        dir_name = '%s/%s' % (base_name, os.path.dirname(file_name))
+        dir_name = '{0}/{1}'.format(base_name, os.path.dirname(file_name))
         if not os.path.exists(dir_name):
             os.makedirs(dir_name)
 
-        print '>> ', file_name
+        print('>> {0}'.format(file_name))
 
         # write content to file
-        f = open('%s/%s' % (base_name, file_name), 'w')
-        f.write(content)
-        f.close()
-
+        with open('{0}/{1}'.format(base_name, file_name), 'w') as f:
+            f.write(content)


### PR DESCRIPTION
Hi Alex,

This is a bug fix in **samples** for Python 3 support:

- use `print()` function (instead of `print` statement),
- use `with` statement to write the output files.
- use `format()` function (instead of `%` operator).
- organize imports.
