### PR TITLE
Add WAI-ARIA role to the nav element for accessibility.

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1100,7 +1100,11 @@ class EpubWriter(object):
             })
 
         body = etree.SubElement(root, 'body')
-        nav = etree.SubElement(body, 'nav', {'{%s}type' % NAMESPACES['EPUB']: 'toc', 'id': 'id'})
+        nav = etree.SubElement(body, 'nav', {
+            '{%s}type' % NAMESPACES['EPUB']: 'toc',
+            'id': 'id',
+            'role': 'doc-toc',
+        })
 
         content_title = etree.SubElement(nav, 'h2')
         content_title.text = self.book.title


### PR DESCRIPTION
Epub accessibility checkers require that all epub:type rules which have corresponding ARIA roles use both. The ebooklib serializer for the nav element doesn't provide any entry point to manually add the `doc-toc` role. This change programmatically adds `role="doc-type"` to the nav at the same point at which `epub:type="toc"` is added.
References:
* [The EPUB-specific rules at the DAISY Ace epub accessibility checker](https://daisy.github.io/ace/rules/epub/)
* [doc-toc role in the Digital publishing WAI-ARIA module 1.0](https://www.w3.org/TR/dpub-aria-1.0/#doc-toc)
* [The DAISY knowledge base on using ARIA in epub](http://kb.daisy.org/publishing/docs/script/aria.html)