### PR TITLE
Fix SVG attributes preserve aspect ratio and view box

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -431,6 +431,12 @@ class EpubHtml(EpubItem):
 
         tree_str = etree.tostring(tree, pretty_print=True, encoding='utf-8', xml_declaration=True)
 
+	# lxml processing converts preserveAspectRatio and viewBox svg atrributes to lowercase
+	# resuling in epub validation error and resultant epub cover doesnt cover full page.
+	# This hack restores the case of these attributes
+	tree_str = tree_str.replace('preserveaspectratio','preserveAspectRatio')
+	tree_str = tree_str.replace('viewbox','viewBox')
+
         return tree_str
 
     def __str__(self):

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -431,8 +431,8 @@ class EpubHtml(EpubItem):
 
         tree_str = etree.tostring(tree, pretty_print=True, encoding='utf-8', xml_declaration=True)
 
-	# lxml processing converts preserveAspectRatio and viewBox svg atrributes to lowercase
-	# resuling in epub validation error and resultant epub cover doesnt cover full page.
+	# lxml processing converts preserveAspectRatio and viewBox svg attributes to lowercase
+	# resulting in epub validation error and resultant epub cover doesn't cover full page.
 	# This hack restores the case of these attributes
 	tree_str = tree_str.replace('preserveaspectratio','preserveAspectRatio')
 	tree_str = tree_str.replace('viewbox','viewBox')


### PR DESCRIPTION
lxml processing at class EpubHtml converts preserveAspectRatio and viewBox svg attributes to lowercase which generates epub validation error and resultant epub cover doesn't cover full page as it should. This hack restores the case of these attributes.