### PR TITLE
Fix ePub file permissions

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1375,7 +1375,7 @@ class EpubWriter(object):
 
     def write(self):
         # check for the option allowZip64
-        self.out = zipfile.ZipFile(self.file_name, 'w', zipfile.ZIP_DEFLATED)
+        self.out = PermissiveZipFile(self.file_name, 'w', zipfile.ZIP_DEFLATED)
         self.out.writestr('mimetype', 'application/epub+zip', compress_type=zipfile.ZIP_STORED)
 
         self._write_container()


### PR DESCRIPTION
By default, [`ZipFile`](https://docs.python.org/3/library/zipfile.html) writes files with a permission of `600` and directories with `775`. This PR changes the file permissions to `644`.

A `600` file permission may cause issues with some ePub reading systems. As far as I know, there is no standard for file permissions. But `775` for directories and `644`/`664` for files are common.

Related code:
- [`ZipFile.writestr`, Python 2.7](https://github.com/python/cpython/blob/2.7/Lib/zipfile.py#L1231)
- [`ZipFile.writestr`, Python 3.6](https://github.com/python/cpython/blob/3.6/Lib/zipfile.py#L1648)