### PR TITLE
Using a more robust XML parser to improve the Epub compatibility

### DIFF
--- a/ebooklib/utils.py
+++ b/ebooklib/utils.py
@@ -31,10 +31,11 @@ def debug(obj):
 
 
 def parse_string(s):
+    parser = etree.XMLParser(recover=True)
     try:
-        tree = etree.parse(io.BytesIO(s.encode('utf-8')))
+        tree = etree.parse(io.BytesIO(s.encode('utf-8')) , parser=parser)
     except:
-        tree = etree.parse(io.BytesIO(s))
+        tree = etree.parse(io.BytesIO(s) , parser=parser)
 
     return tree
 


### PR DESCRIPTION
The executing of `epub.read_epub` will fail with some Epub file. After some digging,I found it is caused by illegal characters in that ebook metadata file. 

Lucky,the current xml lib lxml used by `ebooklib` have an option to handle this situation [recover mode for XMLParser](https://lxml.de/api/lxml.etree.XMLParser-class.html).

I think a better compatibility XML parser is better for the project. 