### PR TITLE
Use double quotes for XML declaration in xml container

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -49,7 +49,7 @@ NAMESPACES = {'XML': 'http://www.w3.org/XML/1998/namespace',
 
 CONTAINER_PATH = 'META-INF/container.xml'
 
-CONTAINER_XML = '''<?xml version='1.0' encoding='utf-8'?>
+CONTAINER_XML = '''<?xml version="1.0" encoding="utf-8"?>
 <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
   <rootfiles>
     <rootfile media-type="application/oebps-package+xml" full-path="%(folder_name)s/content.opf"/>


### PR DESCRIPTION
The XML declaration normally uses double quotes instead of single
quotes, and all the other containers use double quotes for the
declaration string. I want to update this in order to standardize the
declaration string quotes and because some xml parsers balk at single
quotes in the declaration.