### PR TITLE
Add an option to set toc page direction

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -496,8 +496,8 @@ class EpubNav(EpubHtml):
     Represents Navigation Document in the EPUB file.
     """
 
-    def __init__(self, uid='nav', file_name='nav.xhtml', media_type='application/xhtml+xml', title=''):
-        super(EpubNav, self).__init__(uid=uid, file_name=file_name, media_type=media_type, title=title)
+    def __init__(self, uid='nav', file_name='nav.xhtml', media_type='application/xhtml+xml', title='', direction=None):
+        super(EpubNav, self).__init__(uid=uid, file_name=file_name, media_type=media_type, title=title, direction=direction)
 
     def is_chapter(self):
         """
@@ -1133,6 +1133,7 @@ class EpubWriter(object):
             })
 
         body = etree.SubElement(root, 'body')
+        body.set('dir', item.direction)
         nav = etree.SubElement(body, 'nav', {
             '{%s}type' % NAMESPACES['EPUB']: 'toc',
             'id': 'id',


### PR DESCRIPTION
RTL languages like Arabic needs to have consistent right to left direction. However, before this change, there's no ability to change TOC (nav) page  direction to RTL, even with book direction set to RTL.

```python
book = epub.EpubBook()
nav = epub.EpubNav(direction="rtl")
book.add_item(nav)
book.spine.append("nav")
epub.write_epub("toc.epub", book, {})
```

Nav HTML page will have `dir="rtl"`:

```html
  </head>
  <body dir="rtl">
    <nav epub:type="toc" id="id" role="doc-toc">
```