### PR TITLE
Fix: Some readers cannot click on links containing backslashes (\)

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1148,11 +1148,14 @@ class EpubWriter(object):
                 if isinstance(item, tuple) or isinstance(item, list):
                     li = etree.SubElement(ol, 'li')
                     if isinstance(item[0], EpubHtml):
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].file_name, nav_dir_name)})
+                        a = etree.SubElement(li, 'a', {
+                            'href': os.path.relpath(item[0].file_name, nav_dir_name).replace('\\', '/')})
                     elif isinstance(item[0], Section) and item[0].href != '':
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].href, nav_dir_name)})
+                        a = etree.SubElement(li, 'a',
+                                             {'href': os.path.relpath(item[0].href, nav_dir_name).replace('\\', '/')})
                     elif isinstance(item[0], Link):
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].href, nav_dir_name)})
+                        a = etree.SubElement(li, 'a',
+                                             {'href': os.path.relpath(item[0].href, nav_dir_name).replace('\\', '/')})
                     else:
                         a = etree.SubElement(li, 'span')
                     a.text = item[0].title
@@ -1161,11 +1164,12 @@ class EpubWriter(object):
 
                 elif isinstance(item, Link):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.href, nav_dir_name)})
+                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.href, nav_dir_name).replace('\\', '/')})
                     a.text = item.title
                 elif isinstance(item, EpubHtml):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.file_name, nav_dir_name)})
+                    a = etree.SubElement(li, 'a',
+                                         {'href': os.path.relpath(item.file_name, nav_dir_name).replace('\\', '/')})
                     a.text = item.title
 
         _create_section(nav, self.book.toc)
@@ -1203,7 +1207,7 @@ class EpubWriter(object):
                 guide_type = elem.get('type', '')
                 a_item = etree.SubElement(li_item, 'a', {
                     '{%s}type' % NAMESPACES['EPUB']: guide_to_landscape_map.get(guide_type, guide_type),
-                    'href': os.path.relpath(_href, nav_dir_name)
+                    'href': os.path.relpath(_href, nav_dir_name).replace('\\', '/')
                 })
                 a_item.text = _title
 
@@ -1238,7 +1242,7 @@ class EpubWriter(object):
                     _title = label
 
                     a_item = etree.SubElement(li_item, 'a', {
-                        'href': os.path.relpath(_href, nav_dir_name),
+                        'href': os.path.relpath(_href, nav_dir_name).replace('\\', '/'),
                     })
                     a_item.text = _title
 


### PR DESCRIPTION
## Reader

https://www.wps.cn/

or

https://www.wps.com/

### Before repair

![image](https://user-images.githubusercontent.com/35125624/201082491-c6357d3b-1a60-4088-9288-f13ee72e64bb.png)

### After repair

![image](https://user-images.githubusercontent.com/35125624/201082924-d5ef1910-7d71-4620-bddf-ecd57335b976.png)
