### PR TITLE
Add compresslevel

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -298,11 +298,14 @@ pages_title         "Pages"
 spine_direction     True
 package_direction   False
 play_order          {'enabled': False, 'start_from': 1}
+compresslevel       6
 =================   ====================================
 
 In the future version default value for ignore_ncx will be changed. According to the documentation default
 behaviour should be "EPUB 3 Reading Systems must ignore the NCX in favor of the EPUB Navigation Document".
 Because we have been doing wrong this all time we will keep the default behavior to prepare for the change.
+
+compresslevel goes from 0 to 9, where 0 is no compression.
 
 Example when overriding default options:
 

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -870,7 +870,8 @@ class EpubWriter(object):
         'play_order': {
             'enabled': False,
             'start_from': 1
-        }
+        },
+        'compresslevel': 6
     }
 
     def __init__(self, name, book, options=None):
@@ -1363,7 +1364,7 @@ class EpubWriter(object):
 
     def write(self):
         # check for the option allowZip64
-        self.out = zipfile.ZipFile(self.file_name, 'w', zipfile.ZIP_DEFLATED)
+        self.out = zipfile.ZipFile(self.file_name, 'w', zipfile.ZIP_DEFLATED, compresslevel=self.options['compresslevel'])
         self.out.writestr('mimetype', 'application/epub+zip', compress_type=zipfile.ZIP_STORED)
 
         self._write_container()

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     install_requires = [


### PR DESCRIPTION
Hi :smile:, this PR resolves #271 

Usage of the changes:

```python
epub.write_epub('test.epub', book, {"compresslevel": 9})
```

Allowed values for compresslevel are 0 to 9 - see [ZipFile docs](https://docs.python.org/3/library/zipfile.html#zipfile-objects)
The default value is 6, it's also possible to use `None` with same effect