### PR TITLE
Refactored EpubItem content to be IOBase.

### DIFF
--- a/samples/02_cover_create/create.py
+++ b/samples/02_cover_create/create.py
@@ -18,11 +18,11 @@ if __name__ == '__main__':
 
     # intro chapter
     c1 = epub.EpubHtml(title='Introduction', file_name='intro.xhtml', lang='hr')
-    c1.content=u'<html><head></head><body><h1>Introduction</h1><p>Introduction paragraph where i explain what is happening.</p></body></html>'
+    c1.set_content(u'<html><head></head><body><h1>Introduction</h1><p>Introduction paragraph where i explain what is happening.</p></body></html>')
 
     # about chapter
     c2 = epub.EpubHtml(title='About this book', file_name='about.xhtml')
-    c2.content='<h1>About this book</h1><p>Helou, this is my book! There are many books, but this one is mine.</p><p><img src="image.jpg" alt="Cover Image"/></p>'
+    c2.content.write(b'<h1>About this book</h1><p>Helou, this is my book! There are many books, but this one is mine.</p><p><img src="image.jpg" alt="Cover Image"/></p>')
 
     # add chapters to the book
     book.add_item(c1)

--- a/samples/03_advanced_create/create.py
+++ b/samples/03_advanced_create/create.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
 
     # intro chapter
     c1 = epub.EpubHtml(title='Introduction', file_name='intro.xhtml', lang='hr')
-    c1.content=u'<html><head></head><body><h1>Introduction</h1><p>Introduction paragraph where i explain what is happening.</p></body></html>'
+    c1.set_content(u'<html><head></head><body><h1>Introduction</h1><p>Introduction paragraph where i explain what is happening.</p></body></html>')
 
     # defube style
     style = '''BODY { text-align: justify;}'''
@@ -26,7 +26,7 @@ if __name__ == '__main__':
 
     # about chapter
     c2 = epub.EpubHtml(title='About this book', file_name='about.xhtml')
-    c2.content='<h1>About this book</h1><p>Helou, this is my book! There are many books, but this one is mine.</p>'
+    c2.write('<h1>About this book</h1><p>Helou, this is my book! There are many books, but this one is mine.</p>')
     c2.set_language('hr')
     c2.properties.append('rendition:layout-pre-paginated rendition:orientation-landscape rendition:spread-none')
     c2.add_item(default_css)

--- a/samples/04_markdown_parse/epub2markdown.py
+++ b/samples/04_markdown_parse/epub2markdown.py
@@ -20,11 +20,11 @@ if __name__ == '__main__':
             proc = subprocess.Popen(['pandoc', '-f', 'html', '-t', 'markdown', '-'],
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE)
-            content, error = proc.communicate(item.content)
+            content, error = proc.communicate(item.get_content())
             file_name = os.path.splitext(item.file_name)[0] + '.md'
         else:
             file_name = item.file_name
-            content = item.content
+            content = item.get_content()
 
         # create needed directories 
         dir_name = '{0}/{1}'.format(base_name, os.path.dirname(file_name))

--- a/samples/07_pagebreaks/create.py
+++ b/samples/07_pagebreaks/create.py
@@ -17,22 +17,22 @@ if __name__ == '__main__':
 
     # build the chapter HTML and add the page break
     c1 = epub.EpubHtml(title='Introduction', file_name='intro.xhtml', lang='en')
-    c1.content = u'<h1>Introduction</h1><p><span id="page1" epub:type="pagebreak">1</span>This chapter has a visible page number.</p><p><span id="page2" epub:type="pagebreak">2</span>Something else now.</p>'
+    c1.set_content(u'<h1>Introduction</h1><p><span id="page1" epub:type="pagebreak">1</span>This chapter has a visible page number.</p><p><span id="page2" epub:type="pagebreak">2</span>Something else now.</p>')
 
     c2 = epub.EpubHtml(title='Chapter the Second', file_name='chap02.xhtml', lang='en')
-    c2.content = u'<html><head></head><body><h1>Chapter the Second</h1><p>This chapter has two page breaks, both with invisible page numbers.</p>'
+    c2.content.write(u'<html><head></head><body><h1>Chapter the Second</h1><p>This chapter has two page breaks, both with invisible page numbers.</p>'.encode())
 
     # Add invisible page numbers that match the printed text, for accessibility
-    c2.content += create_pagebreak("2")
+    c2.write(create_pagebreak("2"))
 
     # You can add more content  after the page break
-    c2.content += u'<p>This is the second page in the second chapter, after the invisible page break.</p>'
+    c2.write(u'<p>This is the second page in the second chapter, after the invisible page break.</p>')
 
     # Add invisible page numbers that match the printed text, for accessibility
-    c2.content += create_pagebreak("3", label="Page 3")
+    c2.write(create_pagebreak("3", label="Page 3"))
 
     # close the chapter
-    c2.content += u'</body></html>'
+    c2.write(u'</body></html>')
 
     # add chapters to the book
     book.add_item(c1)

--- a/samples/10_large_files/README.md
+++ b/samples/10_large_files/README.md
@@ -1,0 +1,8 @@
+Large create
+============
+
+Creates LARGE EPUB files
+
+## Start
+
+    python create.py

--- a/samples/10_large_files/create.py
+++ b/samples/10_large_files/create.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 from ebooklib import epub
+from tempfile import TemporaryFile
 
 
 if __name__ == '__main__':
@@ -18,8 +19,10 @@ if __name__ == '__main__':
     c1.set_content(u'<html><head></head><body><h1>Introduction</h1><p>Introduction paragraph where i explain what is happening.</p></body></html>')
 
     # about chapter
-    c2 = epub.EpubHtml(title='About this book', file_name='about.xhtml')
-    c2.content.write(b'<h1>About this book</h1><p>Helou, this is my book! There are many books, but this one is mine.</p>')
+    c2 = epub.EpubHtml(title='About this book', file_name='about.xhtml', content=TemporaryFile())
+    c2.write('<h1>About this book</h1>')
+    for i in range(1024):
+        c2.write('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin rutrum erat ipsum, at fringilla sem sodales ut. Donec rutrum condimentum leo, non convallis ipsum sodales vel. Sed vulputate, quam dapibus pharetra viverra, nunc magna fermentum ligula, sed placerat enim diam id nisi. Sed justo nunc, placerat vel rutrum eget, lacinia quis ante. Maecenas semper turpis lectus, sed sollicitudin diam feugiat vitae. Mauris massa felis, cursus non enim a, consequat pulvinar mauris. Proin scelerisque neque felis, in fringilla ligula tristique ac. Phasellus interdum lacus neque, ac efficitur nibh consequat a. Donec enim enim, commodo sed finibus in, dignissim sit amet arcu. Nam mollis eu ipsum sed ornare. Maecenas non ipsum molestie, volutpat nulla quis, accumsan arcu. Cras imperdiet augue interdum ipsum laoreet malesuada vitae consectetur ipsum. Quisque vitae tortor augue.</p>')
 
     # add chapters to the book
     book.add_item(c1)


### PR DESCRIPTION
When creating LARGE EpubItems (gigabyte scale, such as certain comics or other image-heavy media), storage can be kept in other placed than memory. By using the already-defined set_content and get_content, and allowing other base content types (such as TemporaryFile), improves memory usage.