### PR TITLE
Handle missing title from table of contents nodes that have children

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1150,11 +1150,11 @@ class EpubWriter(object):
                 if isinstance(item, tuple) or isinstance(item, list):
                     li = etree.SubElement(ol, 'li')
                     if isinstance(item[0], EpubHtml):
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].file_name, nav_dir_name)})
+                        a = etree.SubElement(li, 'a', {'href': zip_path.relpath(item[0].file_name, nav_dir_name)})
                     elif isinstance(item[0], Section) and item[0].href != '':
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].href, nav_dir_name)})
+                        a = etree.SubElement(li, 'a', {'href': zip_path.relpath(item[0].href, nav_dir_name)})
                     elif isinstance(item[0], Link):
-                        a = etree.SubElement(li, 'a', {'href': os.path.relpath(item[0].href, nav_dir_name)})
+                        a = etree.SubElement(li, 'a', {'href': zip_path.relpath(item[0].href, nav_dir_name)})
                     else:
                         a = etree.SubElement(li, 'span')
                     a.text = item[0].title
@@ -1163,11 +1163,11 @@ class EpubWriter(object):
 
                 elif isinstance(item, Link):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.href, nav_dir_name)})
+                    a = etree.SubElement(li, 'a', {'href': zip_path.relpath(item.href, nav_dir_name)})
                     a.text = item.title
                 elif isinstance(item, EpubHtml):
                     li = etree.SubElement(ol, 'li')
-                    a = etree.SubElement(li, 'a', {'href': os.path.relpath(item.file_name, nav_dir_name)})
+                    a = etree.SubElement(li, 'a', {'href': zip_path.relpath(item.file_name, nav_dir_name)})
                     a.text = item.title
 
         _create_section(nav, self.book.toc)
@@ -1205,7 +1205,7 @@ class EpubWriter(object):
                 guide_type = elem.get('type', '')
                 a_item = etree.SubElement(li_item, 'a', {
                     '{%s}type' % NAMESPACES['EPUB']: guide_to_landscape_map.get(guide_type, guide_type),
-                    'href': os.path.relpath(_href, nav_dir_name)
+                    'href': zip_path.relpath(_href, nav_dir_name)
                 })
                 a_item.text = _title
 
@@ -1240,7 +1240,7 @@ class EpubWriter(object):
                     _title = label
 
                     a_item = etree.SubElement(li_item, 'a', {
-                        'href': os.path.relpath(_href, nav_dir_name),
+                        'href': zip_path.relpath(_href, nav_dir_name),
                     })
                     a_item.text = _title
 

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1570,7 +1570,7 @@ class EpubReader(object):
 
             for a in elems.getchildren():
                 if a.tag == '{%s}navLabel' % NAMESPACES['DAISY']:
-                    label = a.getchildren()[0].text_content()
+                    label = a.getchildren()[0].text
                 if a.tag == '{%s}content' % NAMESPACES['DAISY']:
                     content = a.get('src', '')
                 if a.tag == '{%s}navPoint' % NAMESPACES['DAISY']:

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1422,7 +1422,7 @@ class EpubReader(object):
         meta_inf = self.read_file('META-INF/container.xml')
         tree = parse_string(meta_inf)
 
-        for root_file in tree.findall('//xmlns:rootfile[@media-type]', namespaces={'xmlns': NAMESPACES['CONTAINERNS']}):
+        for root_file in tree.findall('.//xmlns:rootfile[@media-type]', namespaces={'xmlns': NAMESPACES['CONTAINERNS']}):
             if root_file.get('media-type') == 'application/oebps-package+xml':
                 self.opf_file = root_file.get('full-path')
                 self.opf_dir = zip_path.dirname(self.opf_file)

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1570,7 +1570,7 @@ class EpubReader(object):
 
             for a in elems.getchildren():
                 if a.tag == '{%s}navLabel' % NAMESPACES['DAISY']:
-                    label = a.getchildren()[0].text
+                    label = a.getchildren()[0].text_content()
                 if a.tag == '{%s}content' % NAMESPACES['DAISY']:
                     content = a.get('src', '')
                 if a.tag == '{%s}navPoint' % NAMESPACES['DAISY']:
@@ -1608,7 +1608,7 @@ class EpubReader(object):
                 link_node = item_node.find('a')
 
                 if sublist_node is not None:
-                    title = item_node[0].text
+                    title = item_node[0].text_content()
                     children = parse_list(sublist_node)
 
                     if link_node is not None:

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1393,7 +1393,7 @@ class EpubReader(object):
         self._check_deprecated()
 
     def _check_deprecated(self):
-        if not self.options.get('ignore_ncx'):
+        if self.options.get('ignore_ncx') is None:
             warnings.warn('In the future version we will turn default option ignore_ncx to True.')
 
     def process(self):

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -956,7 +956,7 @@ class EpubWriter(object):
 
                             el.text = v[0]
                         except ValueError:
-                            logging.error('Could not create metadata "{}".'.format(name))
+                            logging.info('Could not create metadata "{}".'.format(name))
 
     def _write_opf_manifest(self, root):
         manifest = etree.SubElement(root, 'manifest')

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1617,7 +1617,7 @@ class EpubReader(object):
                     else:
                         items.append((Section(title), children))
                 elif link_node is not None:
-                    title = link_node.text
+                    title = link_node.text_content()
                     href = zip_path.normpath(zip_path.join(base_path, link_node.get('href')))
 
                     items.append(Link(href, title))


### PR DESCRIPTION
Using lxml's .text_content() instead of text because some ToC nodes look like this: 

```
<li>
    <a href="text/chapter-1.xhtml"><span epub:type="z3998:roman">I</span>: Looking-Glass House</a>
</li>
```

This PR fixes that issue by using lxml's nested text extractor instead of using the root node's text alone.