### PR TITLE
Change deprecation check

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1393,7 +1393,7 @@ class EpubReader(object):
         self._check_deprecated()
 
     def _check_deprecated(self):
-        if not self.options.get('ignore_ncx'):
+        if self.options.get('ignore_ncx') is None:
             warnings.warn('In the future version we will turn default option ignore_ncx to True.')
 
     def process(self):


### PR DESCRIPTION
Check for None rather than falsey-ness.

The current problem is that 

```python
book = epub.read_epub('test.epub', options={'ignore_ncx': False})
```

will raise a user warning because the current logic checks for Falsey-ness rather than None. The expected behaviour is that no warning should be raised as the option was passed explicitly (the warning about the default value doesn't matter). This pull request changes the deprecation check to check for None rather than falsey-ness.