### PR TITLE
An extension method for `<meta>` is added to the EpubHtml object

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -257,6 +257,7 @@ class EpubHtml(EpubItem):
         self.media_overlay = media_overlay
         self.media_duration = media_duration
 
+        self.metas = []
         self.links = []
         self.properties = []
         self.pages = []
@@ -296,6 +297,23 @@ class EpubHtml(EpubItem):
           As string returns language code.
         """
         return self.lang
+
+    def add_meta(self, **kwgs):
+        """
+        Add additional <meta> to the document. 
+
+        >>> add_meta(name='viewport', content='width=device-width, initial-scale=1')
+        """
+        self.metas.append(kwgs)
+
+    def get_metas(self):
+        """
+        Returns list of additional metas defined for this document.
+
+        :Returns:
+          As tuple return list of metas.
+        """
+        return (meta for meta in self.metas)
 
     def add_link(self, **kwgs):
         """
@@ -413,6 +431,9 @@ class EpubHtml(EpubItem):
                 _lnk.text = ''
             else:
                 _lnk = etree.SubElement(_head, 'link', lnk)
+
+        for meta in self.metas:
+            _meta = etree.SubElement(_head, 'meta', meta)
 
         # this should not be like this
         # head = html_root.find('head')

--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -420,6 +420,9 @@ class EpubHtml(EpubItem):
 
         _head = etree.SubElement(tree_root, 'head')
 
+        for meta in self.metas:
+            _meta = etree.SubElement(_head, 'meta', meta)
+
         if self.title != '':
             _title = etree.SubElement(_head, 'title')
             _title.text = self.title
@@ -431,9 +434,6 @@ class EpubHtml(EpubItem):
                 _lnk.text = ''
             else:
                 _lnk = etree.SubElement(_head, 'link', lnk)
-
-        for meta in self.metas:
-            _meta = etree.SubElement(_head, 'meta', meta)
 
         # this should not be like this
         # head = html_root.find('head')


### PR DESCRIPTION
When producing EPUBs from images, <svg> is employed to depict the appearance and layout of the images. At this point, it is utilized in conjunction with the `<meta name="viewport" content="" />` syntax.