### PR TITLE
fix: lxml root warning

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1422,7 +1422,7 @@ class EpubReader(object):
         meta_inf = self.read_file('META-INF/container.xml')
         tree = parse_string(meta_inf)
 
-        for root_file in tree.findall('//xmlns:rootfile[@media-type]', namespaces={'xmlns': NAMESPACES['CONTAINERNS']}):
+        for root_file in tree.findall('.//xmlns:rootfile[@media-type]', namespaces={'xmlns': NAMESPACES['CONTAINERNS']}):
             if root_file.get('media-type') == 'application/oebps-package+xml':
                 self.opf_file = root_file.get('full-path')
                 self.opf_dir = zip_path.dirname(self.opf_file)


### PR DESCRIPTION
Fix the following warning when using ebooklib with the latest version of lxml (5.2.1):

> [ebooklib/epub.py:1423](https://github.com/aerkalov/ebooklib/blob/v0.18/ebooklib/epub.py#L1423): FutureWarning: This search incorrectly ignores the root element, and will be fixed in a future version.  If you rely on the current behaviour, change it to './/xmlns:rootfile[@media-type]'