### PR TITLE
Don't ignore IOErrors on write

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1744,10 +1744,7 @@ def write_epub(name, book, options=None):
 
     epub.process()
 
-    try:
-        epub.write()
-    except IOError:
-        pass
+    epub.write()
 
 # READ
 


### PR DESCRIPTION
Ignoring all IOErrors will mean you don't notice when something didn't work on write. In my case the file was already existing, but the process didn't have write permissions so the changes were not written. If unnoticed you could loose a lot of data with this.

Maybe there is a more sophisticated way to handle this, but until then I think it is better to let all exceptions pass through.