### PR TITLE
Update epub.py

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1390,13 +1390,15 @@ class EpubReader(object):
         self.opf_dir = ''
 
         self.options = dict(self.DEFAULT_OPTIONS)
+        self.user_provided_options = options or {}
+        
         if options:
             self.options.update(options)
 
         self._check_deprecated()
 
     def _check_deprecated(self):
-        if self.options.get('ignore_ncx') is None:
+        if 'ignore_ncx' not in self.user_provided_options:
             warnings.warn('In the future version we will turn default option ignore_ncx to True.')
 
     def process(self):


### PR DESCRIPTION
If I understood you correctly.
When you are using the warning - 'In a future version we will set the default ignore_ncx option to True.'
You want the user to explicitly choose how the toc.ncx file is used

My proposal checks that the user explicitly selects the mode of operation rather than using the default.