### PR TITLE
Bug fix. Prevent None join error when HREF is not found on a link_node.

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1614,12 +1614,12 @@ class EpubReader(object):
                     title = item_node[0].text_content()
                     children = parse_list(sublist_node)
 
-                    if link_node is not None:
+                    if link_node is not None and link_node.get('href'):
                         href = zip_path.normpath(zip_path.join(base_path, link_node.get('href')))
                         items.append((Section(title, href=href), children))
                     else:
                         items.append((Section(title), children))
-                elif link_node is not None:
+                elif link_node is not None and link_node.get('href'):
                     title = link_node.text_content()
                     href = zip_path.normpath(zip_path.join(base_path, link_node.get('href')))
 


### PR DESCRIPTION
I have encountered a couple epubs lately that have the condition where one of the `link_node` objects does not have a valid `href`. It's usually when the link node text is filled with whites spaces.

This is a simple and I believe save way to avert the issue.

The change simply checks that a `link_node` has a valid `href` before attempting to use it. This I think is inline with original intention to only process "valid" link nodes.


