### PR TITLE
EpubWriter: use the mtime option as the date_time value of zip metadata

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -22,6 +22,7 @@ import uuid
 import warnings
 import zipfile
 from collections import OrderedDict
+import datetime
 
 import six
 
@@ -904,12 +905,34 @@ class EpubWriter(object):  # noqa: UP004
         "raise_exceptions": False,
         "compresslevel": 6,
     }
+    
+    @classmethod
+    def get_default_options(cls):
+        default = dict(cls.DEFAULT_OPTIONS)
+        default["mtime"] = datetime.datetime.now()
+        return default
+
+    @classmethod
+    def datetime_to_zipinfo_datetime(cls, dt):
+        """
+        Converts a datetime object to a tuple format compatible with zipfile.ZipInfo.
+
+        :Args:
+          - dt: datetime.datetime object
+
+        :Returns:
+          Tuple of (year, month, day, hour, minute, second) for use in ZipInfo
+        """
+        return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
+    
+    def zipinfo(self, name):
+        return zipfile.ZipInfo(name, self.datetime_to_zipinfo_datetime(self.options['mtime']))
 
     def __init__(self, name, book, options=None):
         self.file_name = name
         self.book = book
 
-        self.options = dict(self.DEFAULT_OPTIONS)
+        self.options = self.get_default_options()
         if options:
             self.options.update(options)
 
@@ -937,8 +960,9 @@ class EpubWriter(object):  # noqa: UP004
                         plg.html_before_write(self.book, item)
 
     def _write_container(self):
-        container_xml = CONTAINER_XML % {"folder_name": self.book.FOLDER_NAME}
-        self.out.writestr(CONTAINER_PATH, container_xml)
+
+        container_xml = CONTAINER_XML % {'folder_name': self.book.FOLDER_NAME}
+        self.out.writestr(self.zipinfo(CONTAINER_PATH), container_xml)
 
     def _write_opf_metadata(self, root):
         # This is really not needed
@@ -954,14 +978,9 @@ class EpubWriter(object):  # noqa: UP004
 
         metadata = etree.SubElement(root, "metadata", nsmap=nsmap)
 
-        el = etree.SubElement(metadata, "meta", {"property": "dcterms:modified"})
-        if "mtime" in self.options:
-            mtime = self.options["mtime"]
-        else:
-            import datetime
+        el = etree.SubElement(metadata, 'meta', {'property': 'dcterms:modified'})
+        el.text = self.options['mtime'].strftime('%Y-%m-%dT%H:%M:%SZ')
 
-            mtime = datetime.datetime.now()
-        el.text = mtime.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         for ns_name, values in six.iteritems(self.book.metadata):
             if ns_name == NAMESPACES["OPF"]:
@@ -1110,7 +1129,8 @@ class EpubWriter(object):  # noqa: UP004
     def _write_opf_file(self, root):
         tree_str = etree.tostring(root, pretty_print=True, encoding="utf-8", xml_declaration=True)
 
-        self.out.writestr("{FOLDER_NAME}/content.opf".format(FOLDER_NAME=self.book.FOLDER_NAME), tree_str)  # noqa: UP032
+        self.out.writestr(self.zipinfo("{FOLDER_NAME}/content.opf".format(FOLDER_NAME=self.book.FOLDER_NAME)), tree_str)
+
 
     def _write_opf(self):
         package_attributes = {
@@ -1394,21 +1414,22 @@ class EpubWriter(object):  # noqa: UP004
         for item in self.book.get_items():
             if isinstance(item, EpubNcx):
                 self.out.writestr(
-                    "{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name),  # noqa: UP032
-                    self._get_ncx(),
-                )
+                    self.zipinfo(
+                        "{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name)  # noqa: UP032
+                    ),
+                    self._get_ncx())
             elif isinstance(item, EpubNav):
                 self.out.writestr(
-                    "{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name),  # noqa: UP032
-                    self._get_nav(item),
-                )
+                    self.zipinfo("{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name)  # noqa: UP032
+                                 ),
+                    self._get_nav(item))
             elif item.manifest:
                 self.out.writestr(
-                    "{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name),  # noqa: UP032
-                    item.get_content(),
-                )
+                    self.zipinfo("{FOLDER_NAME}/{file_name}".format(FOLDER_NAME=self.book.FOLDER_NAME, file_name=item.file_name))  # noqa: UP032
+                    , item.get_content())
             else:
-                self.out.writestr("{file_name}".format(file_name=item.file_name), item.get_content())  # noqa: UP032
+                self.out.writestr(self.zipinfo("{file_name}".format(file_name=item.file_name)), item.get_content())
+
 
     def write(self):
         if six.PY2:


### PR DESCRIPTION
Hello there, thanks for this great library.

This pull-request changes sligthly the logic to reuse the "mtime" option as the zip-file metadata "date_time".

As I was generating multiple times the same epub with the exact same content, i was surprised to see that md5 hashes weren't matching for successive generations.

the zipfile library takes a new timestamp at each use of the `writestr` method to set the "date_time" metadata corresponding to [the last modification of the zip file](https://docs.python.org/3/library/zipfile.html#zipfile.ZipInfo.date_time).

This pull requests:
- sets a new datetime in the `mtime` option when initializing a new EpubWriter object
- lets this option still be overriden as expected, for the epub metadata
- reuse this `mtime` option value to fill the metadata of the zip file when writing.

This means:
- the zip file date_time metadata is always aligned with the epub metadata (not very important but i guess it can be nice for consistency)
- when a user sets the `mtime` option, for the same exact content, the epub file obtained will be exactly the same, byte for byte, allowing reproducible builds.

I guess reproducible builds are not exactly a priority, but this could be useful for testing, publishing, and trusting any tool that uses this library.

Thanks again, i'm waiting for your comments and feedback on this.