### PR TITLE
Allow loading data from iostream

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1723,7 +1723,7 @@ class EpubReader(object):
             )
 
     def _load(self):
-        if os.path.isdir(self.file_name):
+        if isinstance(self.file_name, (str, os.PathLike)) and os.path.isdir(self.file_name):
             file_name = self.file_name
 
             class Directory:


### PR DESCRIPTION
If filename is not str or PathLike, do not use isdir detection and directly use ZipFile to read.