### PR TITLE
Fix #347

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -77,15 +77,10 @@ CHAPTER_XML = six.b(
 COVER_XML = six.b("""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en" xml:lang="en">
- <head>
-  <style>
-    body { margin: 0em; padding: 0em; }
-    img { max-width: 100%; max-height: 100%; }
-  </style>
- </head>
- <body>
-   <img src="" alt="" />
- </body>
+  <head></head>
+  <body>
+    <img src="" alt="" style="height:100%; text-align:center" />
+  </body>
 </html>""")
 
 


### PR DESCRIPTION
In `COVER_XML` ([epub.py](https://github.com/aerkalov/ebooklib/blob/master/ebooklib/epub.py)).
Fix #347 by moving CSS from `<style>` in `<head>` to the inline `style` attribute of the `<img>` and replacing the CSS with Booktype's CSS ([https://github.com/booktype/Booktype/blob/master/lib/booktype/convert/epub/cover.py](https://github.com/booktype/Booktype/blob/master/lib/booktype/convert/epub/cover.py)).
In the output, only affects EPUB/cover.xhtml.