### PR TITLE
Fix error introduced in 0dd72c34: namespace needs curly braces

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1515,6 +1515,8 @@ class EpubReader(object):  # noqa: UP004
         nsmap = metadata.nsmap
         nstags = dict(six.iteritems(nsmap))
         default_ns = nstags.get(None, "")
+        if default_ns:
+            default_ns = "{%s}" % default_ns
 
         nsdict = {v: {} for v in nsmap.values()}
 


### PR DESCRIPTION
In the commit with a lot of changes like `dict((k, v) for k, v in t.items())` -> `dict(t.items())` there was this one change from:
`nstags = dict((k, '{%s}' % v) for k, v in six.iteritems(nsmap))`
to:
`nstags = dict(six.iteritems(nsmap))`

https://github.com/aerkalov/ebooklib/commit/0dd72c340ec82429ed33d6cb18baa133d57d29e6#diff-59d9daed77ebdadc75eb0729f0184888bfe29382cba0c1de445dc908df0e5c35L1469

This removed the curly braces, so later `default_ns + "meta"` became sth like `http://www.idpf.org/2007/opfmeta` instead of `{http://www.idpf.org/2007/opf}meta`, messing up reading metadata in 0.20.