### PR TITLE
fix: Correct NCX parsing logic - use AND instead of OR

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -1724,8 +1724,7 @@ class EpubReader(object):  # noqa: UP004
 
         # should read ncx or nav file
         nav_item = next((item for item in self.book.items if isinstance(item, EpubNav)), None)
-        if toc:
-            if not self.options.get("ignore_ncx") or not nav_item:
+        if toc and not self.options.get("ignore_ncx") and not nav_item:
                 try:
                     ncxFile = self.read_file(zip_path.join(self.opf_dir, self.book.get_item_with_id(toc).get_name()))
                 except KeyError:


### PR DESCRIPTION
## Problem
When reading EPUBs created by ebooklib itself with `ignore_ncx=True`, parsing fails with:
AttributeError: 'NoneType' object has no attribute 'get_name'
## Root Cause
Line 1728 had incorrect logic using `or`:
```python
if not self.options.get("ignore_ncx") or not nav_item:
With ignore_ncx=True and nav_item=None, this evaluates to False or True = True, still trying to load NCX.
Fix
Changed or to and:
if toc and not self.options.get("ignore_ncx") and not nav_item:
Now NCX is only loaded when:
- 
toc attribute exists AND
- 
ignore_ncx=False AND  
- 
nav_item=None
Testing
All 9 EPUB tests pass after fix.