### PR TITLE
Convert dcterms:modified into UTC time

### DIFF
--- a/ebooklib/epub.py
+++ b/ebooklib/epub.py
@@ -973,7 +973,8 @@ class EpubWriter(object):  # noqa: UP004
         metadata = etree.SubElement(root, "metadata", nsmap=nsmap)
 
         el = etree.SubElement(metadata, "meta", {"property": "dcterms:modified"})
-        el.text = self.options["mtime"].strftime("%Y-%m-%dT%H:%M:%SZ")
+        time_utc = self.options["mtime"].astimezone(datetime.timezone.utc)
+        el.text = time_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         for ns_name, values in six.iteritems(self.book.metadata):
             if ns_name == NAMESPACES["OPF"]:


### PR DESCRIPTION
When creating an EPUB, ebooklib automatically sets the mandatory `dcterms:modified` metadata. This metadata must contain the date when the EPUB file was last modified, in a specific format, **in UTC time**. (See [the EPUB
specification](https://www.w3.org/TR/epub-33/#sec-metadata-last-modified).) Currently, the value of `dcterms:modified` set by ebooklib is the time in the current time zone, formatted in the required format. This pull request adds a line that converts this time to UTC before writing it.