### PR TITLE
Prevent path traversal in Directory.read()

### DIFF
--- a/ebooklib/utils.py
+++ b/ebooklib/utils.py
@@ -126,7 +126,14 @@ class Directory(object):  # noqa: UP004
         self.directory_path = directory_path
 
     def read(self, subname):
-        with open(os.path.join(self.directory_path, subname), "rb") as fp:
+        directory_path = os.path.realpath(self.directory_path)
+        path = os.path.realpath(os.path.join(directory_path, subname))
+        # Prevent path traversal: manifest hrefs are attacker-controlled and
+        # URL-decoded, so a crafted value such as "../../etc/passwd" must not
+        # be allowed to escape the source directory. See issue #359.
+        if path != directory_path and not path.startswith(directory_path + os.sep):
+            raise OSError(f"Invalid path, escapes the source directory: {subname!r}")
+        with open(path, "rb") as fp:
             return fp.read()
 
     def close(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+import os
+
+import pytest
+
 from ebooklib import epub, utils
 
 
@@ -34,3 +38,21 @@ class TestEpubItemInitialization:
             '<span xmlns:epub="http://www.idpf.org/2007/ops" epub:type="pagebreak"'
             ' title="page1" id="page1">label</span>'
         )
+
+
+class TestDirectory:
+    def test_read_within_directory(self, tmp_path):
+        (tmp_path / "Text").mkdir()
+        (tmp_path / "Text" / "c.xhtml").write_bytes(b"hello")
+
+        directory = utils.Directory(str(tmp_path))
+
+        assert directory.read(os.path.join("Text", "c.xhtml")) == b"hello"
+
+    def test_read_rejects_path_traversal(self, tmp_path):
+        # See #359: a crafted (URL-decoded) manifest href must not be allowed
+        # to escape the source directory.
+        directory = utils.Directory(str(tmp_path))
+
+        with pytest.raises(OSError):
+            directory.read(os.path.join("..", "..", "etc", "passwd"))


### PR DESCRIPTION
## Summary

Fixes #359 (path traversal / CWE-22).

`Directory.read()` joined the source directory with a `subname` taken from EPUB OPF manifest `href` attributes (attacker-controlled, and URL-decoded via `unquote`) without any sanitisation:

```python
open(os.path.join(self.directory_path, subname), "rb")
```

A crafted href such as `../../etc/passwd` (or its percent-encoded form `%2e%2e%2f...`) could escape the intended directory and read arbitrary files from disk.

## Fix

Resolve both the base directory and the requested target with `os.path.realpath` (which also collapses `..` and follows symlinks), then reject any target that does not stay within the base directory before opening it.

```python
def read(self, subname):
    directory_path = os.path.realpath(self.directory_path)
    path = os.path.realpath(os.path.join(directory_path, subname))
    if path != directory_path and not path.startswith(directory_path + os.sep):
        raise OSError(...)
    with open(path, "rb") as fp:
        return fp.read()
```

Legitimate relative hrefs (e.g. `Text/chapter1.xhtml`) are unaffected.

## Tests

Added `TestDirectory` in `tests/test_utils.py`:
- `test_read_within_directory` — a normal in-directory read still works.
- `test_read_rejects_path_traversal` — a `../../` href raises.

## Verification

- `pytest tests/test_utils.py` — passed; full suite: 26 passed.
- `ruff check` and `ruff format --check` — clean.
