### PR TITLE
fix: generate unique ids for multiple authors

### DIFF
--- a/ebooklib/book.py
+++ b/ebooklib/book.py
@@ -55,6 +55,7 @@ class EpubBook:
         self._id_html = 0
         self._id_image = 0
         self._id_static = 0
+        self._id_creator = 0
 
         self.title = ""
         self.language = "en"
@@ -148,9 +149,15 @@ class EpubBook:
         self.add_metadata(None, "meta", "", OrderedDict([("name", "cover"), ("content", "cover-img")]))
 
     def add_author(
-        self, author: str, file_as: str | None = None, role: str | None = None, uid: str = "creator"
+        self, author: str, file_as: str | None = None, role: str | None = None, uid: str | None = None
     ) -> None:
         """Add author for this document"""
+
+        if uid is None:
+            # ids must be unique within the document, so only the first author can use
+            # the plain "creator" id; subsequent ones get a counter suffix
+            uid = "creator" if self._id_creator == 0 else f"creator_{self._id_creator}"
+            self._id_creator += 1
 
         self.add_metadata("DC", "creator", author, {"id": uid})
 

--- a/tests/test_ebook.py
+++ b/tests/test_ebook.py
@@ -396,6 +396,18 @@ class TestEbook:
 
         self._test_metadata(book)
 
+    def test_epubbook_multiple_authors_have_unique_ids(self):
+        book = epub.EpubBook()
+
+        book.add_author("First Author")
+        book.add_author("Second Author")
+        book.add_author("Third Author", uid="third")
+
+        ids = [others["id"] for _, others in book.get_metadata("DC", "creator")]
+
+        assert ids == ["creator", "creator_1", "third"]
+        assert len(set(ids)) == len(ids)
+
     def _test_epubbook(self, name):
         # TODO:
         # - add other roles here besides creator


### PR DESCRIPTION
Closes #356

`add_author()` defaulted `uid` to `"creator"`, so adding two authors without an explicit uid emitted two `dc:creator` elements with `id="creator"` — duplicate ids are invalid per the EPUB spec.

The default is now taken from a per-book counter: the first author still gets the plain `creator` id (output for single-author books is unchanged), subsequent ones get `creator_1`, `creator_2`, and an explicitly passed `uid` is used as-is. Regression test added in `tests/test_ebook.py`; full test suite passes.
